### PR TITLE
Python 3.7 compatibility

### DIFF
--- a/src/blockdiag/utils/myitertools.py
+++ b/src/blockdiag/utils/myitertools.py
@@ -14,33 +14,40 @@
 #  limitations under the License.
 
 from itertools import cycle
+from itertools import islice
 
 
 def istep(seq, step=2):
     iterable = iter(seq)
     while True:
-        yield [next(iterable) for _ in range(step)]
+        item = list(islice(iterable, step))
+        if len(item) < step:
+            break
+        yield item
 
 
 def stepslice(iterable, steps):
-    iterable = iter(iterable)
-    step = cycle(steps)
+    try:
+        iterable = iter(iterable)
+        step = cycle(steps)
 
-    while True:
-        # skip (1)
-        n = next(step)
-        if n == 0:
-            pass
-        elif n == 1:
-            o = next(iterable)
-            yield o
-            yield o
-        else:
-            yield next(iterable)
-            for _ in range(n - 2):
+        while True:
+            # skip (1)
+            n = next(step)
+            if n == 0:
+                pass
+            elif n == 1:
+                o = next(iterable)
+                yield o
+                yield o
+            else:
+                yield next(iterable)
+                for _ in range(n - 2):
+                    next(iterable)
+                yield next(iterable)
+
+            # skip (2)
+            for _ in range(next(step)):
                 next(iterable)
-            yield next(iterable)
-
-        # skip (2)
-        for _ in range(next(step)):
-            next(iterable)
+    except StopIteration:
+        return


### PR DESCRIPTION
See PEP 479 for the breaking changes around iterators, based on
@serhiy-storchaka's suggestions for myitertools.py changes.

Fixes #93 

Best viewed with `--ignore-all-space`: https://github.com/dridi/blockdiag/commit/f68ac237c974c5e4de3ddd0883f911c9bfef8569?w=1