### PR TITLE
Rotate PNG textarea correctly

### DIFF
--- a/src/blockdiag/imagedraw/png.py
+++ b/src/blockdiag/imagedraw/png.py
@@ -335,7 +335,7 @@ class ImageDrawExBase(base.ImageDraw):
             text.textarea(textbox, string, font, **kwargs)
 
             filler = Image.new('RGB', box.size, kwargs.get('fill'))
-            self.paste(filler, box.topleft, text._image.rotate(angle))
+            self.paste(filler, box.topleft, text._image.rotate(angle, expand=1))
             return
 
         lines = self.textfolder(box, string, font, **kwargs)


### PR DESCRIPTION
Before this fix the packetdiag component could not make PNG images and the fix was to
use SVG instead.

With this fix the packetdiag component can generate PNG images without complainting about
"ERROR: images do not match"