### PR TITLE
Catchup recent pillow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,21 @@ matrix:
         - TOXENV=py37
     - python: 'nightly'
       env: TOXENV=py38
+    - python: '3.7'
+      env:
+        - TOXENV=pillow2.x
+    - python: '3.7'
+      env:
+        - TOXENV=pillow3.x
+    - python: '3.7'
+      env:
+        - TOXENV=pillow4.x
+    - python: '3.7'
+      env:
+        - TOXENV=pillow5.x
+    - python: '3.7'
+      env:
+        - TOXENV=pillow6.x
 
 install:
   - sudo apt-get install fonts-ipafont-gothic libjpeg8-dev libfreetype6-dev

--- a/src/blockdiag/imagedraw/png.py
+++ b/src/blockdiag/imagedraw/png.py
@@ -366,6 +366,10 @@ class ImageDrawExBase(base.ImageDraw):
             self.textarea(box, string, _font, **kwargs)
 
     def image(self, box, url):
+        if not box.width or not box.height:
+            # resizing image into "0 width and/or height" is meaningless
+            return
+
         try:
             image = images.open(url, mode='pillow')
 

--- a/src/blockdiag/imagedraw/utils/pillow.py
+++ b/src/blockdiag/imagedraw/utils/pillow.py
@@ -13,14 +13,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+PILLOW_VERSION = (-1, -1, -1)
+
 
 def patch_FreeTypeFont_getsize():
     try:
-        from PIL import PILLOW_VERSION
         from PIL.ImageFont import FreeTypeFont
 
         # Avoid offset problem in Pillow (>= 2.2.0, < 2.6.0)
-        if "2.2.0" <= PILLOW_VERSION < "2.6.0":
+        if (2, 2, 0) <= PILLOW_VERSION < (2, 6, 0):
             original_getsize = FreeTypeFont.getsize
 
             def getsize(self, string):
@@ -35,4 +36,20 @@ def patch_FreeTypeFont_getsize():
 
 
 def apply_patch():
+    try:
+        import PIL
+
+        # check PIL.__version__ at first, because PILLOW_VERSION was
+        # removed at 7.0.0
+        version = getattr(PIL, '__version__', None)
+        if not version:
+            version = getattr(PIL, 'PILLOW_VERSION', '-1.-1.-1')
+
+        global PILLOW_VERSION
+        PILLOW_VERSION = tuple(int(v) for v in version.split('.')[:3])
+    except (ImportError, ValueError):
+        # no need to patch FreeTypeFont.getsize, because Pillow is
+        # "not available" or "changed drastically"
+        return
+
     patch_FreeTypeFont_getsize()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,35,36,37},pillow{2.0,2.2,2.4}
+envlist=py{27,35,36,37},pillow{2.x,3.x,4.x,5.x,6.x}
 
 [testenv]
 usedevelop = True
@@ -8,9 +8,14 @@ extras =
     rst
     testing
 deps =
-    pillow2.0: Pillow<=2.0.9999
-    pillow2.2: Pillow<=2.2.9999
-    pillow2.4: Pillow<=2.4.9999
+    pillow2.x: Pillow<3.0.0
+    pillow3.x: Pillow<4.0.0
+    pillow4.x: Pillow<5.0.0
+    pillow5.x: Pillow<6.0.0
+    pillow6.x: Pillow<7.0.0
+    pillow2.x: reportlab<3.5.0
+    pillow3.x: reportlab<3.5.0
+
 passenv =
     ALL_TESTS
 commands =


### PR DESCRIPTION
This series makes blockdiag catch up recent Pillow library.
I confirmed that testing by tox with ALL_TESTS=1 passes with Pillow versions below.

- 2.0.0
- 2.2.2
- 2.4.0
- 2.9.0 (as the last 2.x)
- 3.0.0
- 3.1.1
- 3.3.0
- 3.4.2 (as the last 3.x)
- 4.3.0 (as the last 4.x)
- 5.4.1 (as the last 5.x)
- 6.2.1 (as the last 6.x)
