### PR TITLE
fix some type issues leading when using python 3

### DIFF
--- a/src/blockdiag/imagedraw/png.py
+++ b/src/blockdiag/imagedraw/png.py
@@ -57,7 +57,7 @@ def dashize_line(line, length):
         if pt1[1] > pt2[1]:
             pt2, pt1 = line
 
-        r = stepslice(range(pt1[1], pt2[1]), length)
+        r = stepslice(range(round(pt1[1]), round(pt2[1])), length)
         for y1, y2 in istep(n for n in r):
             yield [(pt1[0], y1), (pt1[0], y2)]
 
@@ -65,7 +65,7 @@ def dashize_line(line, length):
         if pt1[0] > pt2[0]:
             pt2, pt1 = line
 
-        r = stepslice(range(pt1[0], pt2[0]), length)
+        r = stepslice(range(round(pt1[0]), round(pt2[0])), length)
         for x1, x2 in istep(n for n in r):
             yield [(x1, pt1[1]), (x2, pt1[1])]
     else:  # diagonal
@@ -395,9 +395,9 @@ class ImageDrawExBase(base.ImageDraw):
                 image = image.convert('RGBA')
 
             if image.mode == 'RGBA':
-                self.paste(image, (x, y), mask=image)
+                self.paste(image, (round(x), round(y)), mask=image)
             else:
-                self.paste(image, (x, y))
+                self.paste(image, (round(x), round(y)))
         except IOError:
             pass
 


### PR DESCRIPTION
When using block diagrams, sometimes scaling seems to be leading to faulty types which either `PIL` or `range()` can't handle, resulting in messages like:
```
WARNING: dot code 'blockdiag { ... }': integer argument expected, got float
```

```
TypeError: integer argument expected, got float
Traceback (most recent call last):utes                                                                                                                                                                                                              
  File "/usr/local/lib/python3.7/site-packages/sphinxcontrib/blockdiag.py", line 199, in html_visit_blockdiag
    html_render_png(self, node)
  File "/usr/local/lib/python3.7/site-packages/sphinxcontrib/blockdiag.py", line 152, in html_render_png
    image.save()
  File "/usr/local/lib/python3.7/site-packages/blockdiag/drawer.py", line 187, in save
    return self.drawer.save(self.filename, size, self.format)
  File "/usr/local/lib/python3.7/site-packages/blockdiag/imagedraw/filters/linejump.py", line 181, in save
    self._run()
  File "/usr/local/lib/python3.7/site-packages/blockdiag/imagedraw/filters/linejump.py", line 108, in _run
    method(self.target, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/blockdiag/imagedraw/png.py", line 385, in image
    self.paste(image, (x, y))
  File "/usr/local/lib/python3.7/site-packages/blockdiag/imagedraw/png.py", line 137, in paste
    self._image.paste(image, pt, mask)
  File "/usr/local/lib/python3.7/site-packages/PIL/Image.py", line 1442, in paste
    self.im.paste(im, box)
```

This PR adds `round()` to the input values of affected `range()` and `paste()` calls to ensure the variables are being casted to `int` types.

-----------------------
To test this PR, uninstall the current version `pip3 uninstall blockdiag` followed by `python3 setup.py install`