### PR TITLE
Drop pillow-2.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ matrix:
         - TOXENV=py38
     - python: '3.7'
       env:
-        - TOXENV=pillow2.x
-    - python: '3.7'
-      env:
         - TOXENV=pillow3.x
     - python: '3.7'
       env:

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Execute blockdiag command::
 Requirements
 ============
 * Python 3.5 or later
-* Pillow 2.2.1 or later
+* Pillow 3.0 or later
 * funcparserlib 0.3.6 or later
 * reportlab (optional)
 * wand and imagemagick (optional)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{35,36,37},pillow{2.x,3.x,4.x,5.x,6.x}
+envlist=py{35,36,37},pillow{3.x,4.x,5.x,6.x}
 
 [testenv]
 usedevelop = True
@@ -8,12 +8,10 @@ extras =
     rst
     testing
 deps =
-    pillow2.x: Pillow<3.0.0
     pillow3.x: Pillow<4.0.0
     pillow4.x: Pillow<5.0.0
     pillow5.x: Pillow<6.0.0
     pillow6.x: Pillow<7.0.0
-    pillow2.x: reportlab<3.5.0
     pillow3.x: reportlab<3.5.0
 
 passenv =


### PR DESCRIPTION
Ubuntu 16.04 LTS ships 3.1.2. So it's time to drop old pillow support.