### PR TITLE
remove replacment of codecs.getreader on python 3

### DIFF
--- a/src/blockdiag/utils/compat.py
+++ b/src/blockdiag/utils/compat.py
@@ -16,15 +16,6 @@
 import codecs
 import sys
 
-# replace codecs.getreader
-if sys.version_info[0] == 3:
-    getreader = codecs.getreader
-
-    def py3_getreader(encoding):
-        return lambda stream, *args: getreader(encoding)(stream.buffer, *args)
-
-    codecs.getreader = py3_getreader
-
 
 def cmp_to_key(mycmp):
     """Convert a cmp= function into a key= function"""


### PR DESCRIPTION
The blockdiag.utils.compat module currently replaces the
defintion of codecs.getreader on python3 with a lamda.
The lamda incorrectly tries to dereference a buffer atirrbute
on the past in io stream that does not exists.

This change remove the replacment of the stardard lib function
which is both incorrect and breaks user of blockdiag that expect
the standard defintion.