### PR TITLE
fix "WARNING: cannot import name 'NodeShape' f..."

### DIFF
--- a/src/blockdiag/noderenderer/__init__.py
+++ b/src/blockdiag/noderenderer/__init__.py
@@ -14,8 +14,8 @@
 #  limitations under the License.
 
 from __future__ import division
-
 import pkg_resources
+from blockdiag.noderenderer.base import NodeShape  # NOQA: backward compatibility
 
 renderers = {}
 searchpath = []


### PR DESCRIPTION
The removal of NodeShape in noderenderer/__init__.py seems to be problematic when compiling our docs.

04d9e3c#diff-e0242e53ad4068e87ab8092775bbd377L18

gateways.rst:6: WARNING: cannot import name 'NodeShape' from 'blockdiag.noderenderer' (/usr/local/lib/python3.7/site-packages/blockdiag/noderenderer/__init__.py)

When I pull the single line back in, my build seems to be fixed, but since I don't know where

as discussed https://github.com/blockdiag/blockdiag/pull/111#issuecomment-581019094