### PR TITLE
fix style=none node in pdf

### DIFF
--- a/src/blockdiag/imagedraw/pdf.py
+++ b/src/blockdiag/imagedraw/pdf.py
@@ -124,7 +124,8 @@ class PDFImageDraw(base.ImageDraw):
             self.canvas.setLineWidth(kwargs['thick'])
 
         params = self.set_render_params(**kwargs)
-        self.canvas.rect(x, y, width, height, **params)
+        if kwargs['fill'] != 'none' or kwargs['style'] != 'none':
+            self.canvas.rect(x, y, width, height, **params)
 
         if 'thick' in kwargs:
             self.canvas.setLineWidth(1)


### PR DESCRIPTION
Hi and thank you for maintaining blockdiag.

I have an issue when drawing no style node to pdf.

To convert this code to pdf,

```
{
    default_node_style = none;
    default_node_color = none;
    node_width = 40;
    node_height = 20;
    span_width = 20;
    span_height = 20;
    default_fontsize = 11;

    A -- B;
}
```

I get this output.

![default-no-style](https://user-images.githubusercontent.com/13705786/77821950-8cee8700-7131-11ea-9db9-a8950aeafedb.jpg)


This little node is drawn by `canvas.rect()` always.

When I add an if-statement then the code output this image.

![change-no-style](https://user-images.githubusercontent.com/13705786/77821951-94159500-7131-11ea-8f6e-3c3bc9b1333e.jpg)

