### PR TITLE
Fix syntax error in ancient funcparserlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     python_requires=">=3.5",
     install_requires=[
         'setuptools',
-        'funcparserlib',
+        'funcparserlib>=1.0.0a0',
         'Pillow > 3.0',
         'webcolors',
     ],


### PR DESCRIPTION
Not sure why this has suddenly started happening a couple of days ago, but all our read the docs builds have been failing due to syntax errors in the ancient funcparserlib that is used by this library. There is currently a 1.0.0a0 release, which is needed to get things working again.