### PR TITLE
Make the test suite pass on Fedora 37

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,6 @@ include blockdiag.1
 include tox.ini
 include src/blockdiag/tests/VLGothic/*
 recursive-include examples blockdiagrc *.diag *.png *.svg
-recursive-include src README *.py *.diag *.gif *.png
+recursive-include src README *.py *.diag *.gif *.png invalid.txt
 
 exclude examples/update.sh

--- a/src/blockdiag/tests/test_command.py
+++ b/src/blockdiag/tests/test_command.py
@@ -14,12 +14,14 @@
 #  limitations under the License.
 
 import os
+import sys
 import unittest
 
 from blockdiag.command import BlockdiagApp
-from blockdiag.tests.utils import TemporaryDirectory
+from blockdiag.tests.utils import TemporaryDirectory, capture_stderr
 
 
+@capture_stderr
 class TestBlockdiagApp(unittest.TestCase):
     def test_app_cleans_up_images(self):
         testdir = os.path.dirname(__file__)
@@ -41,6 +43,9 @@ class TestBlockdiagApp(unittest.TestCase):
             app = BlockdiagApp()
             app.register_cleanup_handler(cleanup)  # to get internal state
             app.run(args)
+
+            if 'Could not retrieve:' in sys.stderr.getvalue():
+                raise unittest.SkipTest("No internet access")
 
             self.assertTrue(urlopen_cache)  # check images were cached
             for path in urlopen_cache.values():

--- a/src/blockdiag/tests/test_generate_diagram.py
+++ b/src/blockdiag/tests/test_generate_diagram.py
@@ -104,6 +104,8 @@ def generate(mainfunc, filetype, source, options):
 
         mainfunc(['--debug', '-T', filetype, '-o', tmpfile, source] +
                  list(options))
+        if 'Could not retrieve:' in sys.stderr.getvalue():
+            raise unittest.SkipTest("No internet access")
     finally:
         tmpdir.clean()
 
@@ -150,6 +152,8 @@ def ghostscript_not_found_test():
 
         args = ['-T', 'SVG', '-o', tmpfile, diagpath]
         ret = blockdiag.command.main(args)
+        if 'Could not retrieve:' in sys.stderr.getvalue():
+            raise unittest.SkipTest("No internet access")
         assert 'Could not convert image:' in sys.stderr.getvalue()
         assert ret == 0
     finally:

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,4 @@ description =
 extras =
     testing
 commands =
-    flake8 src
+    flake8 --show-source src


### PR DESCRIPTION
In the upcoming Fedora 37 release, the `ALL_TESTS` test suite for blockdiag 3.0.0 successfully passes with Python 3.10 after adding these changes.