### PR TITLE
Fix deprecation of Pillow ImageDraw textsize()

### DIFF
--- a/src/blockdiag/imagedraw/png.py
+++ b/src/blockdiag/imagedraw/png.py
@@ -273,7 +273,8 @@ class ImageDrawExBase(base.ImageDraw):
     def textlinesize(self, string, font):
         ttfont = ttfont_for(font)
         if ttfont is None:
-            size = self.draw.textsize(string, font=None)
+            left, top, right, bottom = self.draw.textbbox((0, 0), string)
+            size = (right - left, bottom - top)
 
             font_ratio = font.size * 1.0 / FontMap.BASE_FONTSIZE
             size = Size(int(size[0] * font_ratio),
@@ -291,7 +292,8 @@ class ImageDrawExBase(base.ImageDraw):
             if self.scale_ratio == 1 and font.size == FontMap.BASE_FONTSIZE:
                 self.draw.text(xy, string, fill=fill)
             else:
-                size = self.draw.textsize(string)
+                left, top, right, bottom = self.draw.textbbox((0, 0), string)
+                size = (right - left, bottom - top)
                 image = Image.new('RGBA', size)
                 draw = ImageDraw.Draw(image)
                 draw.text((0, 0), string, fill=fill)


### PR DESCRIPTION
Pillow has marked ImageDraw.textsize() as deprecated[1] for removal in version 10. This patch updates blockdiag to use the new recommended method for getting the text height and width.

[1] https://pillow.readthedocs.io/en/stable/deprecations.html#font-size-and-offset-methods