### PR TITLE
Fix writing resulting image to stdout when using -o- option

### DIFF
--- a/src/blockdiag/imagedraw/pdf.py
+++ b/src/blockdiag/imagedraw/pdf.py
@@ -231,6 +231,8 @@ class PDFImageDraw(base.ImageDraw):
         # Ignore size and format parameter; compatibility for ImageDrawEx.
 
         self.canvas.showPage()
+        if self.filename == '-':
+            return self.canvas.getpdfdata()
         self.canvas.save()
 
 

--- a/src/blockdiag/imagedraw/png.py
+++ b/src/blockdiag/imagedraw/png.py
@@ -406,7 +406,7 @@ class ImageDrawExBase(base.ImageDraw):
 
         self._image.thumbnail(size, Image.ANTIALIAS)
 
-        if self.filename:
+        if self.filename and self.filename != '-':
             self._image.save(self.filename, _format)
             image = None
         else:

--- a/src/blockdiag/utils/bootstrap.py
+++ b/src/blockdiag/utils/bootstrap.py
@@ -102,11 +102,15 @@ class Application(object):
                              transparency=self.options.transparency)
         drawer.draw()
 
-        if self.options.size:
-            drawer.save(size=self.options.size)
-        else:
-            drawer.save()
-
+        maybe_an_image = (drawer.save(size=self.options.size)
+                          if self.options.size else drawer.save())
+        if self.options.output == '-' and maybe_an_image:
+            # If output=-, (bytebuffer or string) image returned
+            # dump it to console
+            if isinstance(maybe_an_image, bytes):
+                sys.stdout.buffer.write(maybe_an_image)
+            else:
+                sys.stdout.write(maybe_an_image)
         return 0
 
     def cleanup(self):


### PR DESCRIPTION
Code already handles output '-' as stdout, but fails to create a byte buffer, when output - issued And then on bootstrap fails to dump the resulting image (PNG/SVG) to console.

Test PNG | SVG | pdf, with and without size, with stdout or direct file option

Test (pdf require(d) a font on my system):

font=-f/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf for m in blockdiag seqdiag actdiag nwdiag;do
  (cd $m;pip3 install .)
  for t in png svg pdf;do
    for s in 128x128 ""; do
      n="a;"
      [ "$m" = "nwdiag" ] && n="network 1{a;}"
      echo "$m {$n}" | ~/.local/bin/$m $font -T$t ${s:+--size=}${s} - -o- >/tmp/$m$s.$t
      echo "$m {$n}" | ~/.local/bin/$m $font -T$t ${s:+--size=}${s} - -o /tmp/file_$m$s.$t
    done
  done
done

Visually inspect all 48 resulting files