### PR TITLE
chore: Drop Python 3.7 and 3.8 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install tox and any other packages for test
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,22 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: '3.7'
-            toxenv: py37
-          - python-version: '3.8'
-            toxenv: py38
           - python-version: '3.9'
             toxenv: py39
-          - python-version: '3.8'
-            toxenv: pillow3.x
-          - python-version: '3.8'
-            toxenv: pillow4.x
-          - python-version: '3.8'
-            toxenv: pillow5.x
-          - python-version: '3.8'
-            toxenv: pillow6.x
-          - python-version: '3.8'
-            toxenv: pillow7.x
+          - python-version: '3.9'
+            toxenv: pillow10.x
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Unreleased
+------------------
+* Drop Python 3.7 and 3.8 support
+
 3.0.0 (2021-12-06)
 ------------------
 * Drop python3.6 support

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@
 
 Features
 ========
-* Generate block-diagram from dot like text (basic feature).
+* Generate block-diagram from DOT-like text (basic feature).
 * Multilingualization for node-label (utf-8 only).
 
 You can get some examples and generated images on
@@ -102,8 +102,8 @@ Execute blockdiag command::
 
 Requirements
 ============
-* Python 3.7 or later
-* Pillow 3.0 or later
+* Python 3.9 or later
+* Pillow 10.0 or later
 * funcparserlib 1.0.0a0 or later
 * reportlab (optional)
 * wand and imagemagick (optional)

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Topic :: Software Development",
     "Topic :: Software Development :: Documentation",
@@ -50,11 +48,11 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     install_requires=[
         'setuptools',
         'funcparserlib>=1.0.0a0',
-        'Pillow > 3.0',
+        'Pillow>=10.0',
         'webcolors',
     ],
     extras_require={

--- a/src/blockdiag/utils/rst/directives.py
+++ b/src/blockdiag/utils/rst/directives.py
@@ -391,7 +391,7 @@ class BlockdiagDirective(BlockdiagDirectiveBase):
 
 
 def setup(**kwargs):
-    global directive_options, directive_options_default
+    global directive_options, directive_options_default  # noqa: F824
 
     for key, value in directive_options_default.items():
         directive_options[key] = kwargs.get(key, value)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{37,38,39},pillow{3.x,4.x,5.x,6.x,7.x},flake8
+envlist=py39,pillow10.x,flake8
 
 [testenv]
 usedevelop = True
@@ -8,12 +8,7 @@ extras =
     rst
     testing
 deps =
-    pillow3.x: Pillow<4.0.0
-    pillow4.x: Pillow<5.0.0
-    pillow5.x: Pillow<6.0.0
-    pillow6.x: Pillow<7.0.0
-    pillow7.x: Pillow<8.0.0
-    pillow3.x: reportlab<3.5.0
+    pillow10.x: Pillow<11.0.0
 
 passenv =
     ALL_TESTS


### PR DESCRIPTION
Hello,

I want to contribute to the project (to help with supporting newer Pillow versions, moving from nose to an active testing framework, and other improvements). I'm specifically interested in using `seqdiag`, but I see that this Pillow 3.10 support issue blocks new install of `seqdiag`.

First step is addressing [some GitHub Action errors I'm seeing after forking](https://github.com/egfrazier/blockdiag/actions/runs/19921763773). Specifically the fact that the GitHub Action runners no longer support Python 3.7:

```
Version 3.7 with arch x64 not found The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

I also removed support for Python 3.8 since that's been EoL for a while. Python 3.9 is also EoL, but I left it since it's the latest supported version defined in the project.

The `Test` GitHub Action job will still fail, but that can be addressed by a follow on PR that applies the changes [here](https://github.com/blockdiag/blockdiag/pull/179) by @tjni.

This change will make it easier for people to contribute since they can more easily validate their changes will pass the CI defined upstream.